### PR TITLE
Document Webhook JSON Payload

### DIFF
--- a/source/includes/_webhooks.md
+++ b/source/includes/_webhooks.md
@@ -1,7 +1,27 @@
 Webhooks
 ========
 
+> Example JSON Payload
+
+```json
+{
+  "subscriber": {
+    "id": 1,
+    "first_name": "John",
+    "email_address": "John@example.com",
+    "state": "active",
+    "created_at": "2018-02-15T19:40:24.913Z",
+    "fields": {
+      "My Custom Field": "Value"
+    }
+  }
+}
+
+```
+
 Webhooks are automations that will receive subscriber data when a subscriber event is triggered, such as when a subscriber completes a sequence.
+
+When a webhook is triggered, a `POST` request will be made to your url with a JSON payload.
 
 Create a webhook
 ----------------


### PR DESCRIPTION
We had a recent ticket in helpscout asking about what exactly gets
delivered to webhooks. This change documents the payload.

Screenshot:

<img width="1060" alt="screenshot 2018-02-15 11 43 38" src="https://user-images.githubusercontent.com/1007571/36277440-c325c772-1245-11e8-9dc5-93090e1a2efc.png">
