### PR TITLE
unifying revisions to Purchases docs

### DIFF
--- a/source/includes/_purchases.md
+++ b/source/includes/_purchases.md
@@ -4,16 +4,13 @@ Purchases
 List Purchases
 --------------
 
-> Example request: Retrieve all purchases for an account
+> Example request
 
 ```shell
-curl -X GET https://api.convertkit.com/v3/purchases \
-      -H 'Content-Type: application/json' \
-      -d '{ "api_secret": "<your_secret_api_key>", "page": 1 }'
+curl https://api.convertkit.com/v3/purchases?api_secret=<your_secret_api_key>
 ```
 
-> Success response:
-    `HTTP/1.1 200 OK`
+> Example response
 
 ```json
 {
@@ -106,16 +103,13 @@ Show all purchases for an account
 Retrieve a specific Purchase
 ----------------------------
 
-> Example request: get purchases with ID `8`
+> Example request
 
 ```shell
-curl -X GET https://api.convertkit.com/v3/purchases/8 \
-     -H 'Content-Type: application/json' \
-     -d '{ "api_secret": "<your_secret_api_key>" }
+curl https://api.convertkit.com/v3/purchases/<purchase_id>?api_secret=<your_secret_api_key>
 ```
 
-> Success response:
-    `HTTP/1.1 200 OK`
+> Example response
 
 ```json
 {
@@ -161,17 +155,17 @@ Show specific purchase by ID
 
 ### Endpoint
 
-GET /v3/purchases/#{id}
+GET /v3/purchases/#{purchase_id}
 
 ### Required parameters
 
 -   `api_secret` - Your api secret key.
--   `id` - A purchase ID
+-   `purchase_id` - A purchase ID
 
 Create a Purchase
 -----------------
 
-> Example request: get all purchases
+> Example request
 
 ```shell
 curl -X POST https://api.convertkit.com/v3/purchases \
@@ -208,8 +202,7 @@ curl -X POST https://api.convertkit.com/v3/purchases \
      }'
 ```
 
-> Success response:
-    `HTTP/1.1 201 Created`
+> Example response:
 
 ```json
 {
@@ -292,10 +285,10 @@ Are you building an integration? <a href="mailto:engineers@convertkit.com?subjec
 Update a specific Purchase
 --------------------------
 
-> Example request: update purchases with ID `8`
+> Example request
 
 ```shell
-curl -X PUT https://api.convertkit.com/v3/purchases/8 \
+curl -X PUT https://api.convertkit.com/v3/purchases/<purchase_id> \
      -H 'Content-Type: application/json' \
      -d '{ "api_secret": "<your_secret_api_key>",
            "purchase": {
@@ -304,8 +297,7 @@ curl -X PUT https://api.convertkit.com/v3/purchases/8 \
         }'
 
 ```
-> Success response:
-    `HTTP/1.1 200 OK`
+> Example response
 
 ```json
 {
@@ -351,12 +343,12 @@ Note: `status` is only changeable field
 
 ### Endpoint
 
-PUT /v3/purchases/#{id}
+PUT /v3/purchases/#{purchase_id}
 
 ### Required parameters
 
 -   `api_secret` - Your api secret key.
--   `id` - A purchase ID
+-   `purchase_id` - A purchase ID
 
 #### Optional parameters
 


### PR DESCRIPTION
Closes ConvertKit/convertkit#10357

Changes:
- updated GET requests to query param syntax
- checked POST, PUT request to include required params
- swapped 'id' for 'purchase_id', to match specificity earlier in the docs
- removed "success" request details, to match rest of docs

To do:
- This is the only section that details failing requests.  I think this information is better suited for the "Getting started" section instead, so amended the issue for reviewing that section/will make the edit then (just to keep things straight/changes small)

QA:
- **Please** double-check that the PR is into `master`/is correct 😌 Opening the PR came with a lovely note to make sure it's not going to lord/slate; I think it's good now--but second eyes never hurt!
- Still need to check my commands via command-line, to make sure they work as advertised.  Based on the `API::V3::PurchasesController` code, should be good

<!--
⚠️ 🚨 ⚠️  STOP AND READ THIS ⚠️ 🚨 ⚠️

👆👆 see that 'base fork' dropdown above? You should change it! The default value of "lord/slate" submits your change to ALL USERS OF SLATE, not just your company. This is PROBABLY NOT WHAT YOU WANT.
-->