### PR TITLE
unifying revisions to Custom Fields docs

### DIFF
--- a/source/includes/_custom_fields.md
+++ b/source/includes/_custom_fields.md
@@ -1,7 +1,7 @@
 Custom fields
 =============
 
-A custom field allows you to collect subscriber information beyond the standard fields of first name and email address. An example would be a custom field called last name so you can get the full names of your subscribers. You create a custom field, and then you're able to use that in your forms or with the API (see the subscribers endpoint for adding custom field values to a subscriber.)
+A custom field allows you to collect subscriber information beyond the standard fields of first name and email address. An example would be a custom field called last name so you can get the full names of your subscribers. You create a custom field, and then you're able to use that in your forms or with the API (see the Subscribers endpoint for adding custom field values to a subscriber.)
 
 Note that you must create a custom field before you can use it with the subscribe methods on the forms, sequences, and tags endpoints.
 
@@ -70,7 +70,7 @@ curl -X POST https://api.convertkit.com/v3/custom_fields\
            "label": ["Occupation", "Location"] }'
 ```
 
-> Response: Single custom field
+> Example response: Single custom field
 
 ```json
 {
@@ -81,7 +81,7 @@ curl -X POST https://api.convertkit.com/v3/custom_fields\
 }
 ```
 
-> Response: Multiple custom fields
+> Example response: Multiple custom fields
 
 ```json
 [{
@@ -109,7 +109,7 @@ POST /v3/custom_fields
 ### Required parameters
 
 -   `api_secret` - Your api secret key.
--   `label` or `labels`- The label(s) of the custom field.
+-   `label` - The label(s) of the custom field.
 
 
 Update field
@@ -129,7 +129,7 @@ curl -X PUT https://api.convertkit.com/v3/custom_fields/1\
 No content will be returned.
 ```
 
-Updates a custom field label (see create field above for more information on labels). Note that the key and the name do not change even when the label is updated.
+Updates a custom field label (see Create field above for more information on labels). Note that the key and the name do not change even when the label is updated.
 
 ### Endpoint
 


### PR DESCRIPTION
Closes ConvertKit/convertkit#10356

Summary of changes: Mostly grammar touch-ups for consistency with other sections.  Biggest change was removing `labels` as a required param under "Create fields". Based on the controller code, we wouldn't process `labels` as a valid param key:

snippet of API::V3::CustomFieldsController: 
```
def create
        unless params[:label].present?
          unprocessable_entity("You must specify the label parameter")
        end

        labels = Array.wrap(params[:label])

        @custom_fields = labels.map { |label| @api_account.subscriber_custom_fields.new(label: label) }

        if @custom_fields.all?(&:valid?)
          @custom_fields.each(&:save)

          render :create, status: :created, location: api_v3_custom_fields_path
        else
          unprocessable_entity(@custom_fields.reject(&:valid?).map { |f| f.errors.full_messages.join(". ") }.join("\n"))
        end
      end
```
<!--
⚠️ 🚨 ⚠️  STOP AND READ THIS ⚠️ 🚨 ⚠️

👆👆 see that 'base fork' dropdown above? You should change it! The default value of "lord/slate" submits your change to ALL USERS OF SLATE, not just your company. This is PROBABLY NOT WHAT YOU WANT.
-->