### PR TITLE
revise based on new limits to subscriber custom field processing

### DIFF
--- a/source/includes/_subscribers.md
+++ b/source/includes/_subscribers.md
@@ -168,7 +168,7 @@ PUT /v3/subscribers/#{subscriber_id}
 -   `email_address` - Updated email address for the subscriber.
 -   `fields` - Updated custom fields for your subscriber as object of key/value pairs (the custom field must exist before you can use it here).
 
-_NOTE: The API response returned when updating custom fields is dependent on the number of custom fields in the request, as shown by the examples at right. **A maximum of 125 custom fields are allowed.** Requests that exceed this limit will return a response of_ `413`.
+_NOTE: The API response returned when updating custom fields is dependent on the number of custom fields in the request, as shown by the examples at right. **A maximum of 125 custom fields are allowed.** Requests that exceed this limit will return a response of_ `400`.
 
 
 Unsubscribe subscriber

--- a/source/includes/_subscribers.md
+++ b/source/includes/_subscribers.md
@@ -118,7 +118,24 @@ curl -X PUT https://api.convertkit.com/v3/subscribers/<subscriber_id>\
            } }'
 ```
 
-> Example response
+> Example response: Up to 10 custom fields, status `200`
+
+```json
+{
+  "subscriber": {
+    "id": 1,
+    "first_name": "Jon",
+    "email_address": "jonsnow@example.com",
+    "state": "active",
+    "created_at": "2016-02-28T08:07:00Z",
+    "fields": {
+      "last_name": "Snow"
+    }
+  }
+}
+```
+
+> Example response: 11 to 125 custom fields, status `202`
 
 ```json
 {
@@ -150,6 +167,8 @@ PUT /v3/subscribers/#{subscriber_id}
 -   `first_name` - Updated first name for the subscriber.
 -   `email_address` - Updated email address for the subscriber.
 -   `fields` - Updated custom fields for your subscriber as object of key/value pairs (the custom field must exist before you can use it here).
+
+_NOTE: The API response returned when updating custom fields is dependent on the number of custom fields in the request, as shown by the examples at right. **A maximum of 125 custom fields are allowed.** Requests that exceed this limit will return a response of_ `413`.
 
 
 Unsubscribe subscriber


### PR DESCRIPTION
Closes Convertkit/convertkit#10965

Adding a note, example responses based on changes to the API::V3::SubscribersController#update endpoint in https://github.com/ConvertKit/convertkit/pull/10938 

TLDR of changes is that up to 10 custom fields will be processed inline, 11-125 as a background job, and requests of more than 125 will be rejected as exceeding the custom-field limit.  Not 100% on the example return for 11-125; looks like the only difference would be the status code.

Talked w Justin; he's got some additional updates to Getting Started planned for Friday--those will resolve details about the rate-limiting note.

<!--
⚠️ 🚨 ⚠️  STOP AND READ THIS ⚠️ 🚨 ⚠️

👆👆 see that 'base fork' dropdown above? You should change it! The default value of "lord/slate" submits your change to ALL USERS OF SLATE, not just your company. This is PROBABLY NOT WHAT YOU WANT.
-->