### PR TITLE
unifying revision to Webhooks docs

### DIFF
--- a/source/includes/_webhooks.md
+++ b/source/includes/_webhooks.md
@@ -146,10 +146,10 @@ These are the available event types:
 Destroy webhook
 ---------------
 
-> Example request: Delete webhook automation rule with ID #456.
+> Example request
 
 ```shell
-curl -X DELETE https://api.convertkit.com/v3/automations/hooks/456
+curl -X DELETE https://api.convertkit.com/v3/automations/hooks/<rule_id>
      -H 'Content-Type: application/json'\
      -d '{ "api_secret": "<your_secret_api_key>" }'
 ```


### PR DESCRIPTION
Closes ConvertKit/convertkit#10355

Summary: Tiny change to example request header, so it matches the rest 
<!--
⚠️ 🚨 ⚠️  STOP AND READ THIS ⚠️ 🚨 ⚠️

👆👆 see that 'base fork' dropdown above? You should change it! The default value of "lord/slate" submits your change to ALL USERS OF SLATE, not just your company. This is PROBABLY NOT WHAT YOU WANT.
-->